### PR TITLE
Fix install path of `lib/jwalk/*` files

### DIFF
--- a/lib/jwalk/install.sh
+++ b/lib/jwalk/install.sh
@@ -17,7 +17,7 @@ PREFIX="${1%/}"
 } >&2
 
 mkdir -p "$PREFIX/lib"
-cp -Rv "$JWALK_LIB/jwalk/"* "$JWALK_LIB/jwalk.sh" "$PREFIX/lib"
+cp -Rv "$JWALK_LIB/jwalk" "$JWALK_LIB/jwalk.sh" "$PREFIX/lib"
 
 mkdir -p "$PREFIX/bin"
 ln -Fvs "../lib/jwalk.sh" "$PREFIX/bin/jwalk"


### PR DESCRIPTION
Files `lib/jwalk/*` should be installed as `$PREFIX/lib/jwalk/*`, but currently they are installed as `$PREFIX/lib/*`:
```
$ sh lib/jwalk.sh --install ~/
'/home/kakkoko/src/jwalk/lib/jwalk/examine.awk' -> '/home/kakkoko/lib/examine.awk'
'/home/kakkoko/src/jwalk/lib/jwalk/install.sh' -> '/home/kakkoko/lib/install.sh'
'/home/kakkoko/src/jwalk/lib/jwalk/parse.awk' -> '/home/kakkoko/lib/parse.awk'
'/home/kakkoko/src/jwalk/lib/jwalk/tokenize.sh' -> '/home/kakkoko/lib/tokenize.sh'
'/home/kakkoko/src/jwalk/lib/jwalk.sh' -> '/home/kakkoko/lib/jwalk.sh'
'/home/kakkoko/bin/jwalk' -> '../lib/jwalk.sh'
$ jwalk
sh: 0: Can't open /home/kakkoko/lib/jwalk/tokenize.sh
awk: fatal: can't open source file `/home/kakkoko/lib/jwalk/parse.awk' for reading (No such file or directory)
awk: fatal: can't open source file `/home/kakkoko/lib/jwalk/examine.awk' for reading (No such file or directory)
```